### PR TITLE
fix field view in admin panel list

### DIFF
--- a/lib/iblockfield.php
+++ b/lib/iblockfield.php
@@ -69,10 +69,24 @@ class IBlockField {
         if(!is_array($value["VALUE"]))
             $value = static::ConvertFromDB($arProperty, $value);
         $ar = $value["VALUE"];
-        if($ar)
-            return htmlspecialcharsEx($ar["TYPE"].":".$ar["TEXT"]);
-        else
-            return "&nbsp;";
+        if($ar) {
+            if (is_array($ar)) {
+                return htmlspecialcharsEx($ar["TYPE"].":".$ar["TEXT"]);
+            }
+            if (is_string($ar)) {
+                $json = json_decode($ar, true);
+                $text = [];
+                foreach($json as $line) {
+                    if (is_array($line['data'])) {
+                        continue;
+                    }
+                    $text[] = $line['data'];
+                }
+                return implode("<br>", $text);
+            }
+        }
+        
+        return "&nbsp;";
     }
 
     public static function GetPublicEditHTML($arProperty, $value, $strHTMLControlName)


### PR DESCRIPTION
В списке элементов в админке в случае использования свойства Блочный редактор не выводится значения
![вакансии ДО](https://github.com/user-attachments/assets/63f4800b-0d79-4e24-920d-c2ef44aa2c7e)


После изменений есть вывод
![вакансии ПОСЛЕ](https://github.com/user-attachments/assets/9a0e0ec3-10b3-4faf-ad52-2b2af7c0736e)

